### PR TITLE
remove "Edit in Fiddle" link

### DIFF
--- a/public/examples.ejs
+++ b/public/examples.ejs
@@ -244,14 +244,6 @@
                     <li class="left">
                       <a id="tab-code" role="tab" aria-selected="false">Code</a>
                     </li>
-                    <li class="action-link right">
-                        <a href="#" id="jsfiddle-link">
-                            <svg class="left">
-                                <use xlink:href="#edit_icon"></use>
-                            </svg>
-                            Edit in JSFiddle
-                        </a>
-                    </li>
                 </ul>
                 <div class="tabs-content">
                     <section id="tab-content-features" role="tabpanel" aria-hidden="false" class="content active">


### PR DESCRIPTION
There is no fiddle, the link just goes to #, and I would have replaced the # with an actual fiddle, but it appears there isn't one.  Add one if you know where it is...